### PR TITLE
Fix predictor model loading

### DIFF
--- a/src/agents/contextual_emotion_predictor_agent.py
+++ b/src/agents/contextual_emotion_predictor_agent.py
@@ -23,9 +23,14 @@ class ContextualEmotionPredictor:
         self.debug = debug
         self.label_list = label_list
 
-        # Load tokenizer and model
-        self.tokenizer = AutoTokenizer.from_pretrained("microsoft/DialoGPT-small")
-        self.tokenizer.pad_token = self.tokenizer.eos_token
+        # Load tokenizer and model. Using the same model_path ensures the
+        # tokenizer matches the fine-tuned model checkpoint rather than the
+        # base DialoGPT tokenizer.
+        self.tokenizer = AutoTokenizer.from_pretrained(model_path)
+        if getattr(self.tokenizer, "pad_token", None) is None:
+            # Some conversational models do not define a pad token. For
+            # classification we fall back to the EOS token for padding.
+            self.tokenizer.pad_token = self.tokenizer.eos_token
         self.model = AutoModelForSequenceClassification.from_pretrained(model_path)
         self.model.to(self.device)
         self.model.eval()

--- a/src/agents/emotion_intent_recognizer_agent.py
+++ b/src/agents/emotion_intent_recognizer_agent.py
@@ -21,12 +21,14 @@ class EmotionIntentRecognizer:
         self.emotion_tokenizer = RobertaTokenizer.from_pretrained(emotion_model_path)
         self.emotion_model = RobertaForSequenceClassification.from_pretrained(emotion_model_path)
         self.emotion_model.to(self.device)
+        self.emotion_model.eval()
         self.emotion_labels = emotion_labels
 
         # Load intent model & tokenizer
         self.intent_tokenizer = RobertaTokenizer.from_pretrained(intent_model_path)
         self.intent_model = RobertaForSequenceClassification.from_pretrained(intent_model_path)
         self.intent_model.to(self.device)
+        self.intent_model.eval()
         self.intent_labels = intent_labels
 
     def process(self, dialogue_history):


### PR DESCRIPTION
## Summary
- load tokenizer from the predictor model directory
- set eval mode for emotion/intent models

## Testing
- `pytest -q` *(fails: FileNotFoundError for intent_labels.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840c261377c832e8b31867f757b8269